### PR TITLE
Add support for Python plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ If you have any questions, please join our IRC channel on [irc.rizon.net #runeli
 Open the project in your IDE as a Maven project, build the root module and then run the RuneLite class in runelite-client.  
 For more information visit the [RuneLite Wiki](https://github.com/runelite/runelite/wiki).
 
+## Python Plugins
+
+To create a Python plugin, follow these steps:
+
+1. Write your Python script and save it in the `python-plugins` directory.
+2. Ensure your script contains the necessary logic for the plugin.
+3. Start the RuneLite client, and your Python plugin will be loaded automatically.
+
 ### License
 
 RuneLite is licensed under the BSD 2-clause license. See the license header in the respective file to be sure.

--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -107,6 +107,7 @@ public class RuneLite
 	public static final File SCREENSHOT_DIR = new File(RUNELITE_DIR, "screenshots");
 	public static final File LOGS_DIR = new File(RUNELITE_DIR, "logs");
 	public static final File DEFAULT_SESSION_FILE = new File(RUNELITE_DIR, "session");
+	public static final File PYTHON_PLUGINS_DIR = new File(RUNELITE_DIR, "python-plugins");
 
 	private static final int MAX_OKHTTP_CACHE_SIZE = 20 * 1024 * 1024; // 20mb
 	public static String USER_AGENT = "RuneLite/" + RuneLiteProperties.getVersion() + "-" + RuneLiteProperties.getCommit() + (RuneLiteProperties.isDirty() ? "+" : "");
@@ -349,6 +350,7 @@ public class RuneLite
 		pluginManager.loadCorePlugins();
 		pluginManager.loadSideLoadPlugins();
 		externalPluginManager.loadExternalPlugins();
+		pluginManager.loadPythonPlugins();
 
 		SplashScreen.stage(.70, null, "Finalizing configuration");
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/PluginClassLoader.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/PluginClassLoader.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import org.python.util.PythonInterpreter;
 
 class PluginClassLoader extends URLClassLoader
 {
@@ -52,6 +53,14 @@ class PluginClassLoader extends URLClassLoader
 		{
 			// fall back to main class loader
 			return parent.loadClass(name);
+		}
+	}
+
+	public void loadPythonScript(String scriptPath)
+	{
+		try (PythonInterpreter pyInterp = new PythonInterpreter())
+		{
+			pyInterp.execfile(scriptPath);
 		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/PluginManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/PluginManager.java
@@ -17,8 +17,7 @@
  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
  * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
  * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
@@ -88,6 +87,7 @@ public class PluginManager
 	 */
 	private static final String PLUGIN_PACKAGE = "net.runelite.client.plugins";
 	private static final File SIDELOADED_PLUGINS = new File(RuneLite.RUNELITE_DIR, "sideloaded-plugins");
+	private static final File PYTHON_PLUGINS = new File(RuneLite.RUNELITE_DIR, "python-plugins");
 
 	private final boolean developerMode;
 	private final boolean safeMode;
@@ -309,6 +309,33 @@ public class PluginManager
 				catch (PluginInstantiationException | IOException ex)
 				{
 					log.error("error sideloading plugin", ex);
+				}
+			}
+		}
+	}
+
+	public void loadPythonPlugins()
+	{
+		File[] files = PYTHON_PLUGINS.listFiles();
+		if (files == null)
+		{
+			return;
+		}
+
+		for (File f : files)
+		{
+			if (f.getName().endsWith(".py"))
+			{
+				log.info("Loading Python plugin {}", f);
+
+				try
+				{
+					PythonPlugin plugin = new PythonPlugin(f.getAbsolutePath());
+					plugins.add(plugin);
+				}
+				catch (Exception ex)
+				{
+					log.error("Error loading Python plugin", ex);
 				}
 			}
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/PythonPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/PythonPlugin.java
@@ -1,0 +1,28 @@
+package net.runelite.client.plugins;
+
+import org.python.util.PythonInterpreter;
+
+public class PythonPlugin extends Plugin
+{
+    private final String script;
+
+    public PythonPlugin(String script)
+    {
+        this.script = script;
+    }
+
+    @Override
+    protected void startUp() throws Exception
+    {
+        try (PythonInterpreter pyInterp = new PythonInterpreter())
+        {
+            pyInterp.execfile(script);
+        }
+    }
+
+    @Override
+    protected void shutDown() throws Exception
+    {
+        // Implement any necessary shutdown logic for the Python plugin
+    }
+}


### PR DESCRIPTION
Implement support for Python plugins in the RuneLite client.

* Add `PythonPlugin` class to handle Python plugins.
* Modify `PluginClassLoader` to support loading Python scripts using Jython.
* Update `PluginManager` to recognize and load Python plugins.
* Add `loadPythonPlugins` method in `PluginManager` to load Python plugins from the `python-plugins` directory.
* Update `RuneLite` class to initialize and load Python plugins.
* Update `README.md` to include instructions for creating and using Python plugins.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Thetruemank/runelite?shareId=cbf83f27-bcff-4ff5-8225-5acd0d95ad44).